### PR TITLE
enhance: store `api_key` as `Cow<'static, str>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,19 @@ To use the MusixMatch API, you need an API key. Follow these steps to obtain an 
 ```rust
 use musixmatch::MusixAbgleich;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Create an instance of MusixAbgleich
     let musicabgleich = MusixAbgleich::new("your_api_key",&|error|{
         // Custom error handler for handling errors 
     })
 
     // Call methods with default arguments
-    let artists = musicabgleich.top_artists_by_country(Some("US"), None, None);
+    let artists = musicabgleich.top_artists_by_country(Some("US"), None, None).await;
     println!("{:?}", artists);
 
     //Or when using marcos feature
-    let marco_feature_artist = top_artists_by_country!(musicabgleich,country = "US");
+    let marco_feature_artist = top_artists_by_country!(musicabgleich,country = "US").await;
     println!("{:?}", marco_feature_artist);
 }
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,13 +38,13 @@ use crate::{
 ///
 /// The `MusixAbgleich` struct provides the necessary functionality to interact with the
 /// MusicMatch API, including sending requests and handling errors.
-pub struct MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send {
+pub struct MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send {
     client : Client,
-    api_key: Cow<'static, str>, 
+    api_key: Cow<'a, str>, 
     error_resolver : F //&'a (dyn Fn(RequestError<Value>) + Sync + Send)
 }
 
-impl<F> RequestInfo for MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send  {
+impl<'a, F> RequestInfo for MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send  {
     const BASE_URL : &'static str = "https://api.musixmatch.com/ws/1.1";
     
     fn client(&self) -> &Client {
@@ -52,22 +52,22 @@ impl<F> RequestInfo for MusixAbgleich<F> where F : Fn(RequestError<Value>) + Syn
     }
 }
 
-impl<F> RequestModifiers for MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send {}
+impl<'a, F> RequestModifiers for MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send {}
 
-impl<F> RequestDefaults for MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send { 
+impl<'a, F> RequestDefaults for MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send { 
     fn default_parameters(&self,request_builder: RequestBuilder) -> RequestBuilder {
         request_builder.query(&[("apikey", &self.api_key)])
     }
 }
 
-impl<T,O,E,F> RequestHandler<T,O,E> for MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send  ,T : DeserializeOwned,O : DeserializeOwned,E : DeserializeOwned {}
+impl<'a, T,O,E,F> RequestHandler<T,O,E> for MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send  ,T : DeserializeOwned,O : DeserializeOwned,E : DeserializeOwned {}
 
 /// At this moment these endpoints are not implemented 
 /// * catalogue.dump.get 
 /// * work.post 
 /// * work.validity.post 
 /// * track.richsync 
-impl<F> MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send {
+impl<'a, F> MusixAbgleich<'a, F> where F : Fn(RequestError<Value>) + Sync + Send {
     /// Constructs a new instance of the MusixAbgleich type.
     ///
     /// This function creates a new MusixAbgleich instance with the provided API key and error resolver.
@@ -77,7 +77,7 @@ impl<F> MusixAbgleich<F> where F : Fn(RequestError<Value>) + Sync + Send {
     ///
     /// * `api_key` - A reference to a string representing the API key used for authentication.
     /// * `error_resolver` - This is responsible for handling errors that occur during API requests.
-    pub fn new(api_key : impl Into<Cow<'static, str>>,error_resolver : F) -> Self {
+    pub fn new(api_key : impl Into<Cow<'a, str>>,error_resolver : F) -> Self {
         MusixAbgleich {
             client : Client::new(),
             api_key : api_key.into(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,122 +25,122 @@ use crate::{
 
 
 default_args! { 
-    export pub async fn top_artists_by_country<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,country : Option<&str> = None,page : Option<u16>  = None,page_size : Option<u8>  = None) -> Option<Vec<Artist>> {
+    export pub async fn top_artists_by_country<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,country : Option<&str> = None,page : Option<u16>  = None,page_size : Option<u8>  = None) -> Option<Vec<Artist>> {
         musicabgleich.top_artists_by_country(country,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn top_tracks_by_country<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,country : Option<&str> = None,chart_name : Option<Chart> = None,has_lyrics : Option<bool> = None,page : Option<u16> = None,page_size : Option<u8> = None) -> Option<Vec<Track>> {
+    export pub async fn top_tracks_by_country<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,country : Option<&str> = None,chart_name : Option<Chart> = None,has_lyrics : Option<bool> = None,page : Option<u16> = None,page_size : Option<u8> = None) -> Option<Vec<Track>> {
         musicabgleich.top_tracks_by_country(country,chart_name,has_lyrics,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn track<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,title : Option<&str> = None,artist : Option<&str> = None,album : Option<&str> = None) -> Option<Track> {
+    export pub async fn track<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,title : Option<&str> = None,artist : Option<&str> = None,album : Option<&str> = None) -> Option<Track> {
         musicabgleich.track(title,artist,album).await
     }
 }
 
 default_args! { 
-    export pub async fn track_lyrics<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,title : Option<&str> = None,artist : Option<&str> = None) -> Option<Lyrics> {
+    export pub async fn track_lyrics<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,title : Option<&str> = None,artist : Option<&str> = None) -> Option<Lyrics> {
         musicabgleich.track_lyrics(title,artist).await
     }
 }
 
 default_args! { 
-    export pub async fn track_subtitle<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,commontrack_id : u32 = None,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> /*seconds*/ = None,format : Option<SubtitleFormat> = None) -> Option<Subtitle> {
+    export pub async fn track_subtitle<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,commontrack_id : u32 = None,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> /*seconds*/ = None,format : Option<SubtitleFormat> = None) -> Option<Subtitle> {
         musicabgleich.track_subtitle(commontrack_id,subtitle_length,max_deviation,format).await
     }
 }
 
 default_args! { 
-    export pub async fn subtitle<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,title : Option<&str> = None,artist : Option<&str> = None,album : Option<&str> = None,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> /*seconds*/ = None) -> Option<Track> {
+    export pub async fn subtitle<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,title : Option<&str> = None,artist : Option<&str> = None,album : Option<&str> = None,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> /*seconds*/ = None) -> Option<Track> {
         musicabgleich.subtitle(title,artist,album,subtitle_length,max_deviation).await
     }
 }
 
 default_args! { 
-    export pub async fn track_lyrics_translations_with_track_irsc<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
+    export pub async fn track_lyrics_translations_with_track_irsc<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
         musicabgleich.track_lyrics_translations_with_track_irsc(id,min_completed,selected_language).await
     }
 }
 
 default_args! { 
-    export pub async fn track_lyrics_translations_with_musixbrainx_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
+    export pub async fn track_lyrics_translations_with_musixbrainx_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
         musicabgleich.track_lyrics_translations_with_musixbrainx_id(id,min_completed,selected_language).await
     }
 }
 
 default_args! { 
-    export pub async fn track_lyrics_translations_with_track_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None/*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
+    export pub async fn track_lyrics_translations_with_track_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None/*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
         musicabgleich.track_lyrics_translations_with_track_id(id,min_completed,selected_language).await
     }
 }
 
 default_args! { 
-    export pub async fn track_lyrics_translations_with_commontrack_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
+    export pub async fn track_lyrics_translations_with_commontrack_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */) -> Option<Lyrics> { 
         musicabgleich.track_lyrics_translations_with_commontrack_id(id,min_completed,selected_language).await
     }
 }
 
 default_args! { 
-    export pub async fn track_subtitle_translations_with_track_isrc<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> = None /*seconds*/)-> Option<Subtitle> {
+    export pub async fn track_subtitle_translations_with_track_isrc<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> = None /*seconds*/)-> Option<Subtitle> {
         musicabgleich.track_subtitle_translations_with_track_isrc(id,min_completed,selected_language,subtitle_length,max_deviation).await
     }
 }
 
 default_args! { 
-    export pub async fn track_subtitle_translations_with_commontrack_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> = None /*seconds*/)-> Option<Subtitle> {
+    export pub async fn track_subtitle_translations_with_commontrack_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: &str,min_completed : Option<f32> = None /*percent*/,selected_language : Option<&str> = None/* (ISO 639-1) */,subtitle_length/*seconds*/ : Option<u16> = None,max_deviation : Option<u8> = None /*seconds*/)-> Option<Subtitle> {
         musicabgleich.track_subtitle_translations_with_commontrack_id(id,min_completed,selected_language,subtitle_length,max_deviation).await
     }
 }
 
 default_args! { 
-    export pub async fn search_artist<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, artist_song: Option<&str> = None, artist_id: Option<u32> = None, artist_mbid: Option<&str> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Artist> {
+    export pub async fn search_artist<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, artist_song: Option<&str> = None, artist_id: Option<u32> = None, artist_mbid: Option<&str> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Artist> {
         musicabgleich.search_artist(artist_song,artist_id,artist_mbid,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn artist_relating_albums_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id:u32 ,album_name: Option<bool> = None,release_date_sort: Option<SortBy> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Album>> {
+    export pub async fn artist_relating_albums_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id:u32 ,album_name: Option<bool> = None,release_date_sort: Option<SortBy> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Album>> {
         musicabgleich.artist_relating_albums_with_id(id,album_name,release_date_sort,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn artist_relating_albums_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id:u32 ,album_name: Option<bool> = None,release_date_sort: Option<SortBy> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Album>> {
+    export pub async fn artist_relating_albums_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id:u32 ,album_name: Option<bool> = None,release_date_sort: Option<SortBy> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Album>> {
         musicabgleich.artist_relating_albums_with_musixbrainz_id(id,album_name,release_date_sort,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn artist_relating_artist_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,id:u32,page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Artist>> {
+    export pub async fn artist_relating_artist_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,id:u32,page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Artist>> {
         musicabgleich.artist_relating_artist_with_id(id,page,page_size).await
     }
 }
 
 default_args! { 
-    export pub async fn artist_relating_artist_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>,id:u32,page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Artist>> {
+    export pub async fn artist_relating_artist_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>,id:u32,page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Artist>> {
         musicabgleich.artist_relating_artist_with_musixbrainz_id(id,page,page_size).await
     }
 }
 
 default_args! { 
-    export async fn album_tracks_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: u32 , has_lyrics: Option<bool> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Track>> {
+    export async fn album_tracks_with_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: u32 , has_lyrics: Option<bool> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Track>> {
         musicabgleich.album_tracks_with_id(id,has_lyrics,page,page_size).await
     } 
 }
 
 default_args! { 
-    export async fn album_tracks_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<F>, id: u32 , has_lyrics: Option<bool> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Track>> {
+    export async fn album_tracks_with_musixbrainz_id<F : Fn(RequestError<Value>) + Sync + Send>(musicabgleich : &MusixAbgleich<'a,F>, id: u32 , has_lyrics: Option<bool> = None, page: Option<u32> = None, page_size: Option<u8> = None) -> Option<Vec<Track>> {
         musicabgleich.album_tracks_with_musixbrainz_id(id,has_lyrics,page,page_size).await
     }     
 }
 
 default_args!{
     export async fn search_track<F : Fn(RequestError<Value>) + Sync + Send>(
-        musicabgleich : &MusixAbgleich<F>,
+        musicabgleich : &MusixAbgleich<'a,F>,
         song_title: Option<&str>,
         song_artist: Option<&str>,
         lyrics_contain_word: Option<&str>,


### PR DESCRIPTION
close #1 

with `api_key: impl Into<Cow<'static, str>>`, we could accept various type of a string, provide a more flexible API while avoid unneeded copy
